### PR TITLE
Update python_version for 3.13

### DIFF
--- a/carbonblack.json
+++ b/carbonblack.json
@@ -12,7 +12,7 @@
     "product_name": "Carbon Black",
     "product_version_regex": "[5-7]\\.[0-9]\\.*",
     "min_phantom_version": "5.5.0",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "latest_tested_versions": [
         "On-prem, Version 6.1.0",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)