### PR TITLE
fix: harden Carbon Black connector workflows [Codex]

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Carbon Black Response
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1407,7 +1407,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/carbonblack.json
+++ b/carbonblack.json
@@ -20,7 +20,7 @@
     ],
     "logo": "logo_carbonblack.svg",
     "logo_dark": "logo_carbonblack_dark.svg",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "configuration": {
         "device_url": {
             "data_type": "string",
@@ -32,7 +32,7 @@
             "data_type": "boolean",
             "description": "Verify server certificate",
             "order": 1,
-            "default": false
+            "default": true
         },
         "api_token": {
             "data_type": "password",

--- a/carbonblack_connector.py
+++ b/carbonblack_connector.py
@@ -1,6 +1,6 @@
 # File: carbonblack_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1157,7 +1157,9 @@ class CarbonblackConnector(BaseConnector):
             # Download file from server
             url = f"/v1/cblr/session/{session_id}/file/{file_id}/content"
 
-            response = requests.get(f"{self._rest_uri}{url}", headers={"X-Auth-Token": self._api_token}, stream=True, verify=False)  # nosemgrep
+            ret_val, response = self._make_rest_call(url, action_result, parse_response_json=False)
+            if phantom.is_fail(ret_val):
+                return action_result.get_status()
 
             guid = uuid.uuid4()
 
@@ -1410,6 +1412,16 @@ class CarbonblackConnector(BaseConnector):
         if not sensors:
             return (action_result.set_status(phantom.APP_ERROR, "Unable to find endpoint, sensor list was empty"), None)
 
+        if phantom.is_ip(ip_hostname):
+            sensors = [
+                sensor
+                for sensor in sensors
+                if any(adapter.split(",", 1)[0].strip() == ip_hostname for adapter in sensor.get("network_adapters", "").split("|"))
+            ]
+        else:
+            normalized_hostname = ip_hostname.rstrip(".").casefold()
+            sensors = [sensor for sensor in sensors if str(sensor.get("computer_name", "")).rstrip(".").casefold() == normalized_hostname]
+
         sensors = [x for x in sensors if x.get("status") == "Online"]
 
         if not sensors:
@@ -1452,6 +1464,15 @@ class CarbonblackConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return (action_result.get_status(), None)
 
+        ret_val, updated_sensor = self._make_rest_call(f"/v1/sensor/{endpoint_id}", action_result)
+        if phantom.is_fail(ret_val):
+            return (action_result.get_status(), None)
+        if bool(updated_sensor.get("network_isolation_enabled")) != state:
+            return (
+                action_result.set_status(phantom.APP_ERROR, "Endpoint isolation state was not confirmed by the server"),
+                None,
+            )
+
         return (phantom.APP_SUCCESS, sensors)
 
     def _unblock_hash(self, param):
@@ -1462,9 +1483,7 @@ class CarbonblackConnector(BaseConnector):
         url = f"/v1/banning/blacklist/{unblock_hash}"
 
         # make a rest call to unblock the hash
-        ret_val, response = self._make_rest_call(
-            url, action_result, method="delete", parse_response_json=False, additional_succ_codes={409: None}
-        )
+        ret_val, response = self._make_rest_call(url, action_result, method="delete", parse_response_json=False)
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -1522,9 +1541,7 @@ class CarbonblackConnector(BaseConnector):
         data["enabled"] = True
 
         # make a rest call to set the hash state
-        ret_val, response = self._make_rest_call(
-            "/v1/banning/blacklist", action_result, method="post", data=data, parse_response_json=False, additional_succ_codes={409: None}
-        )
+        ret_val, response = self._make_rest_call("/v1/banning/blacklist", action_result, method="post", data=data, parse_response_json=False)
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -2013,21 +2030,34 @@ class CarbonblackConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             self.debug_print(action_result.get_message())
             self.set_status(phantom.APP_ERROR, action_result.get_message())
-            return phantom.APP_ERROR
+            return None
 
-        total_results = response.get("total_results")
-        result = response["results"]
+        try:
+            total_results = int(response["total_results"])
+            result = response["results"]
+            if total_results < 0 or not isinstance(result, list):
+                raise ValueError
+        except (KeyError, TypeError, ValueError):
+            action_result.set_status(phantom.APP_ERROR, "Carbon Black returned invalid pagination metadata")
+            return None
 
         # start indicates records which helps to traverse the records
         start = len(result)
         result_list.extend(result)
+        if max_containers and int(max_containers) <= len(result_list):
+            return result_list[:max_containers]
+        page_count = 1
         while start < total_results:
+            page_count += 1
+            if page_count > MAX_PAGINATION_PAGES:
+                action_result.set_status(phantom.APP_ERROR, CARBONBLACK_ERROR_PAGINATION_LIMIT)
+                return None
             endpoint_temp = f"{endpoint}&start={start}"
             ret_val, response = self._make_rest_call(endpoint_temp, action_result)
             if phantom.is_fail(ret_val):
                 self.debug_print(action_result.get_message())
                 self.set_status(phantom.APP_ERROR, action_result.get_message())
-                return phantom.APP_ERROR
+                return None
 
             result = response["results"]
             result_list.extend(result)
@@ -2051,6 +2081,8 @@ class CarbonblackConnector(BaseConnector):
         action_result = self.add_action_result(phantom.ActionResult(param))
         max_containers = None
 
+        checkpoint_time = datetime.datetime.now().strftime(DT_STR_FORMAT)
+
         if self.is_poll_now():
             # Manual poll
             max_containers = int(param.get(phantom.APP_JSON_CONTAINER_COUNT))
@@ -2067,11 +2099,8 @@ class CarbonblackConnector(BaseConnector):
             )
 
         result_list = self._paginator(endpoint, action_result, max_containers)
-
-        if not self.is_poll_now():
-            # save last_ingested_time into the state file
-            self._state["last_ingested_time"] = datetime.datetime.now().strftime(DT_STR_FORMAT)
-            self.save_state(self._state)
+        if result_list is None:
+            return action_result.get_status()
 
         for result in result_list:
             cef = {}
@@ -2101,6 +2130,10 @@ class CarbonblackConnector(BaseConnector):
                 self.debug_print(f"stat/msg {status}/{msg}")
                 action_result.set_status(phantom.APP_ERROR, f"Container creation failed: {msg}")
                 return status
+
+        if not self.is_poll_now():
+            self._state["last_ingested_time"] = checkpoint_time
+            self.save_state(self._state)
 
         return action_result.set_status(phantom.APP_SUCCESS)
 

--- a/carbonblack_consts.py
+++ b/carbonblack_consts.py
@@ -1,6 +1,6 @@
 # File: carbonblack_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,6 +94,8 @@ CARBONBLACK_ERROR_INVALID_PATH = "Windows cannot find specified path"
 CARBONBLACK_ERROR_INVALID_DEST_FILE = "Please check if the destination filename already exists at the specified path"
 CARBONBLACK_ERROR_INVALID_INTEGER_VALUE = 'Please provide a valid {msg} integer value in the "{param}"'
 MAX_POLL_TRIES = 10
+MAX_PAGINATION_PAGES = 1000
+CARBONBLACK_ERROR_PAGINATION_LIMIT = "Alert pagination exceeded the safe page limit"
 
 CARBONBLACK_FINISHED_PROCESSING = "Finished Processing {0:.0%}"
 

--- a/carbonblack_file_details.html
+++ b/carbonblack_file_details.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: carbonblack_file_details.html
-  Copyright (c) 2016-2025 Splunk Inc.
+  Copyright (c) 2016-2026 Splunk Inc.
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
@@ -85,23 +85,17 @@
           {% endif %}
           <a style="font-size: large"
              href="javascript:;"
-             onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ result.md5 }}' }], 0, {{ container.id }}, null, false);">
+             onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ result.md5|escapejs }}' }], 0, {{ container.id }}, null, false);">
             {{ result.md5 }}
             &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
           </a>
         </p>
-        {% if result.message %}
-          <p>
-            {% autoescape off %}
-              {{ result.message }}
-            {% endautoescape %}
-          </p>
-        {% endif %}
+        {% if result.message %}<p>{{ result.message }}</p>{% endif %}
         {% if result.data.file_details %}
           <p class="cb-subheader-style">
             <b>Original Filename:</b>
             <a href="javascript:;"
-               onclick="context_menu(this, [{'contains': ['file name', 'process name'], 'value': '{{ result.data.file_details.original_filename }}' }], 0, {{ container.id }}, null, false);">
+               onclick="context_menu(this, [{'contains': ['file name', 'process name'], 'value': '{{ result.data.file_details.original_filename|escapejs }}' }], 0, {{ container.id }}, null, false);">
               {{ result.data.file_details.original_filename }}
               &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
             </a>
@@ -122,7 +116,7 @@
               </td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ result.md5 }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['md5', 'hash'], 'value': '{{ result.md5|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.md5 }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
               </td>
@@ -134,7 +128,7 @@
                 </td>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': {{ result.vault_contains }}, 'value': '{{ result.data.vault_id }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': {{ result.vault_contains }}, 'value': '{{ result.data.vault_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ result.data.vault_id }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
@@ -215,7 +209,7 @@
               </td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['file name', 'process name'], 'value': '{{ result.data.file_details.original_filename }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['file name', 'process name'], 'value': '{{ result.data.file_details.original_filename|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.data.file_details.original_filename }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
               </td>
@@ -226,7 +220,7 @@
               </td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains': ['file name', 'process name'], 'value': '{{ result.data.file_details.internal_name }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains': ['file name', 'process name'], 'value': '{{ result.data.file_details.internal_name|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.data.file_details.internal_name }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span></a>
               </td>
@@ -266,7 +260,7 @@
                 <tr>
                   <td>
                     <a href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_path }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['file path'], 'value': '{{ curr_path|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ curr_path }}
                       &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                     </a>
@@ -288,14 +282,14 @@
                 <tr>
                   <td>
                     <a href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['host name'], 'value': '{{ curr_endpoint.host }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['host name'], 'value': '{{ curr_endpoint.host|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ curr_endpoint.host }}
                       &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                     </a>
                   </td>
                   <td>
                     <a href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['carbon black sensor id'], 'value': '{{ curr_endpoint.sensor }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['carbon black sensor id'], 'value': '{{ curr_endpoint.sensor|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       {{ curr_endpoint.sensor }}
                       &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                     </a>
@@ -329,7 +323,7 @@
             <th>Vault Id</th>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': {{ result.vault_contains }}, 'value': '{{ result.data.vault_id }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': {{ result.vault_contains }}, 'value': '{{ result.data.vault_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.data.vault_id }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </td>

--- a/carbonblack_view.py
+++ b/carbonblack_view.py
@@ -1,6 +1,6 @@
 # File: carbonblack_view.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/query_results.html
+++ b/query_results.html
@@ -13,7 +13,7 @@
 {% endblock %}
 {% block widget_content %}
   <!-- File: query_results.html
-  Copyright (c) 2016-2025 Splunk Inc.
+  Copyright (c) 2016-2026 Splunk Inc.
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
@@ -52,7 +52,7 @@
                              max-width:auto">
                     {% if cell.contains and cell.value and cell.value != None %}
                       <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': {{ cell.contains }}, 'value':'{{ cell.value }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': {{ cell.contains }}, 'value':'{{ cell.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ cell.value }}
                         &nbsp;<span class="fa fa-caret-down"></span>
                       </a>

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,8 @@
 **Unreleased**
 
-* Added secure TLS defaults, validated downloads, exact endpoint isolation, bounded polling, reliable checkpoints, and safe widget rendering.
+* Enabled TLS certificate verification by default and routed file downloads through the configured REST client.
+* Required exact endpoint matches and verified that endpoint isolation changes were applied by the server.
+* Reported conflicting hash ban and unban requests as failures instead of treating them as successful.
+* Bounded alert pagination and honored the configured maximum container count.
+* Advanced the ingestion checkpoint only after all retrieved alerts were processed successfully.
+* Escaped dynamic values rendered in file-detail and query-result widgets.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Added secure TLS defaults, validated downloads, exact endpoint isolation, bounded polling, reliable checkpoints, and safe widget rendering.


### PR DESCRIPTION
## Summary

This PR hardens Carbon Black Response connector behavior across the Flashpoint findings tracked by [PAPP-37953](https://splunk.atlassian.net/browse/PAPP-37953).

- Enables TLS certificate verification by default and applies the asset setting to live-response downloads.
- Rejects failed downloads, ambiguous endpoint matches, unconfirmed isolation changes, and blocklist conflicts.
- Bounds alert pagination and commits polling checkpoints only after all containers save successfully.
- Escapes dynamic widget values and renders result messages with automatic HTML escaping.

## Tracking

PSAAS-30605, PSAAS-30836, PSAAS-30875, PSAAS-30946, PSAAS-31768, PSAAS-31871, PSAAS-31904, PSAAS-32014, PSAAS-32032, PSAAS-32067, PSAAS-32287, PSAAS-32342, and PSAAS-32404. VULN and legacy FS provenance is retained in PAPP-37953.

## Validation

- Focused `pre-commit` suite, including SOAR App Linter, Semgrep, generated docs, release notes, and static tests: passed.
- Python compilation and JSON parsing: passed.

Written and implemented by Codex.
